### PR TITLE
Add AirPods battery info

### DIFF
--- a/filter.cpp
+++ b/filter.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <regex>
 #include <array>
+#include <vector>
 #include <set>
 #include <cstdio>
 #include <memory>
@@ -42,14 +43,23 @@ int prepend_to_PATH(string path) {
     return setenv("PATH", new_PATH.c_str(), 1);
 }
 
-/* Regex match unique substr */
-string regex_match_substr(string input, regex pattern) {
-    smatch match;
-    if (!regex_search(input, match, pattern)) {
-        cerr << "regex match failed for: " << input << '\n';
+/* Regex search for substring */
+vector<string> regex_match_substr(string input_str, regex pattern) {
+    vector<string> results;
+    for (
+        sregex_iterator i = sregex_iterator(input_str.begin(), input_str.end(), pattern);
+        i != sregex_iterator();
+        ++i
+    ) {
+        smatch match = *i;
+        string match_str = match.str();
+        results.push_back(match_str);
+    }
+    if (results.empty()) {
+        cerr << "no regex match; input: " << input_str << '\n';
         exit(1);
     }
-    return match.str();
+    return results;
 }
 
 int main() {
@@ -65,9 +75,9 @@ int main() {
     /* Get currently selected device ids */
     string raw_current_output = exec(get_current_input.c_str());
     string raw_current_input = exec(get_current_output.c_str());
-    regex two_digits_regex("[0-9]{2}");
-    string current_output_id = regex_match_substr(raw_current_output, two_digits_regex);
-    string current_input_id = regex_match_substr(raw_current_input, two_digits_regex);
+    regex two_digits("[0-9]{2}");
+    string current_output_id = regex_match_substr(raw_current_output, two_digits)[0];
+    string current_input_id = regex_match_substr(raw_current_input, two_digits)[0];
     set<string> current_devices = {current_output_id, current_input_id};
     
     /* Parse SwitchAudioSource JSON */
@@ -87,14 +97,15 @@ int main() {
     }
     
     /* Construct script filter JSON */
+    string nozoom = get_env_var("NOZOOM"); 
+    string airpods_battery = get_env_var("AIRPODS_BATTERY");
     picojson::object result;
     picojson::array items;
-    string nozoom = get_env_var("NOZOOM");
     const picojson::value::array& devices = v.get<picojson::array>();
     for (picojson::value::array::const_reverse_iterator i = devices.rbegin(); i != devices.rend(); ++i) {
         
         const picojson::value::object& device = (*i).get<picojson::object>();
-        string name = device.at("name").get<string>();        
+        string name = device.at("name").get<string>();       
         if (nozoom == "true" && name == "ZoomAudioDevice") {
             continue;
         }
@@ -104,14 +115,27 @@ int main() {
         picojson::object variables;
         picojson::object icon;
         
+        if (airpods_battery == "true") {
+            string subtitle;
+            if (name.find("AirPods") != string::npos) {
+                if (subtitle.empty()) {
+                    string raw_battery_data = exec("defaults read /Library/Preferences/com.apple.Bluetooth | grep 'BatteryPercentLeft\\|BatteryPercentRight\\|BatteryPercentCase'");
+                    regex one_to_three_digits("[0-9]{1,3}");
+                    vector<string> battery_data = regex_match_substr(raw_battery_data, one_to_three_digits);
+                    subtitle = "         L: "+battery_data[1]+"%  R: "+battery_data[2]+"%  Case: "+battery_data[0]+'%';
+                }
+                item["subtitle"] = picojson::value(subtitle);
+            }
+        }
+                
         if (current_devices.contains(id)) {
             item["title"] = picojson::value("\u25c9   "+name);
             variables["selected"] = picojson::value("true");
-            
         } else {
             item["title"] = picojson::value("\u25cb   "+name);
             variables["selected"] = picojson::value("false");
         }
+        
         variables["type"] = picojson::value(type);
         icon["path"] = picojson::value(type+".icns");
         item["arg"] = picojson::value(name);

--- a/filter.cpp
+++ b/filter.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <regex>
 #include <array>
+#include <vector>
 #include <set>
 #include <cstdio>
 #include <memory>
@@ -42,6 +43,25 @@ int prepend_to_PATH(string path) {
     return setenv("PATH", new_PATH.c_str(), 1);
 }
 
+/* Regex search for substring */
+vector<string> regex_match_substr(string input_str, regex pattern) {
+    vector<string> results;
+    for (
+        sregex_iterator i = sregex_iterator(input_str.begin(), input_str.end(), pattern);
+        i != sregex_iterator();
+        ++i
+    ) {
+        smatch match = *i;
+        string match_str = match.str();
+        results.push_back(match_str);
+    }
+    if (results.empty()) {
+        cerr << "no regex match; input: " << input_str << '\n';
+        exit(1);
+    }
+    return results;
+}
+
 int main() {
     
     /* Construct SwitchAudioSource commands */
@@ -55,18 +75,10 @@ int main() {
     /* Get currently selected device ids */
     string raw_current_output = exec(get_current_input.c_str());
     string raw_current_input = exec(get_current_output.c_str());
-    smatch current_output_id;
-    smatch current_input_id;
-    regex rgx("[0-9]{2}");
-    if (!regex_search(raw_current_output, current_output_id, rgx)) {
-        cerr << "current output id not found" << '\n';
-        exit(1);
-    }
-    if (!regex_search(raw_current_input, current_input_id, rgx)) {
-        cerr << "current input id not found" << '\n';
-        exit(1);
-    }
-    set<string> current_devices = {current_output_id[0], current_input_id[0]};
+    regex two_digits("[0-9]{2}");
+    string current_output_id = regex_match_substr(raw_current_output, two_digits)[0];
+    string current_input_id = regex_match_substr(raw_current_input, two_digits)[0];
+    set<string> current_devices = {current_output_id, current_input_id};
     
     /* Parse SwitchAudioSource JSON */
     string json = regex_replace(exec(get_json.c_str()), regex("\n"), ",");
@@ -85,14 +97,15 @@ int main() {
     }
     
     /* Construct script filter JSON */
+    string nozoom = get_env_var("NOZOOM"); 
+    string airpods_battery = get_env_var("AIRPODS_BATTERY");
     picojson::object result;
     picojson::array items;
     const picojson::value::array& devices = v.get<picojson::array>();
     for (picojson::value::array::const_reverse_iterator i = devices.rbegin(); i != devices.rend(); ++i) {
         
         const picojson::value::object& device = (*i).get<picojson::object>();
-        string name = device.at("name").get<string>();
-        string nozoom = get_env_var("NOZOOM");        
+        string name = device.at("name").get<string>();       
         if (nozoom == "true" && name == "ZoomAudioDevice") {
             continue;
         }
@@ -102,14 +115,27 @@ int main() {
         picojson::object variables;
         picojson::object icon;
         
+        if (airpods_battery == "true") {
+            string subtitle;
+            if (name.find("AirPods") != string::npos) {
+                if (subtitle.empty()) {
+                    string raw_battery_data = exec("defaults read /Library/Preferences/com.apple.Bluetooth | grep 'BatteryPercentLeft\\|BatteryPercentRight\\|BatteryPercentCase'");
+                    regex one_to_three_digits("[0-9]{1,3}");
+                    vector<string> battery_data = regex_match_substr(raw_battery_data, one_to_three_digits);
+                    subtitle = "         L: "+battery_data[1]+"%  R: "+battery_data[2]+"%  Case: "+battery_data[0]+'%';
+                }
+                item["subtitle"] = picojson::value(subtitle);
+            }
+        }
+                
         if (current_devices.contains(id)) {
             item["title"] = picojson::value("\u25c9   "+name);
             variables["selected"] = picojson::value("true");
-            
         } else {
             item["title"] = picojson::value("\u25cb   "+name);
             variables["selected"] = picojson::value("false");
         }
+        
         variables["type"] = picojson::value(type);
         icon["path"] = picojson::value(type+".icns");
         item["arg"] = picojson::value(name);


### PR DESCRIPTION
CHANGES
- If AirPods are connected, these changes would retrieve their battery info and display in subtitle
- Also adds an env var setting for turning off this functionality

PROBLEM
- I can't actually reliably get updated AirPods battery info
- I'm using the `defaults read [...]` method detailed [here](https://apple.stackexchange.com/questions/328091/airpods-battery-level-with-ioreg) and elsewhere
- The numbers it returns rarely update even when they do elsewhere (e.g. in the sound menu of macOS's control panel)

If anyone has ideas for solving this problem / alternative ways of getting the battery info I'd love to hear it!